### PR TITLE
- Merge-Upstream: Rebased recent commits from rileytestut/AltSign - possibly removes need for 2FA code on iOS 18.1+

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,8 +7,8 @@ import PackageDescription
 let package = Package(
     name: "AltSign",
     platforms: [
-        .iOS(.v12),
-        .macOS(.v10_14)
+        .iOS(.v14),
+        .macOS(.v11),
     ],
     products: [
 		// MARK: - AltSign

--- a/Sources/AltSign/ALTAppleAPI+Authentication.swift
+++ b/Sources/AltSign/ALTAppleAPI+Authentication.swift
@@ -408,8 +408,9 @@ private extension ALTAppleAPI {
 
                     let errorCode = status["ec"] as? Int ?? 0
                     guard errorCode != 0 else { return completionHandler(.success(dictionary)) }
-
-                    switch errorCode {
+                    
+                    switch errorCode
+                    {
                     case -20101, -22406: throw ALTAppleAPIError(.incorrectCredentials)
                     case -22421: throw ALTAppleAPIError(.invalidAnisetteData)
                     default:

--- a/Sources/AltSign/ALTAppleAPI+Authentication.swift
+++ b/Sources/AltSign/ALTAppleAPI+Authentication.swift
@@ -11,7 +11,21 @@ import Foundation
 @_exported import CAltSign
 import CAltSign.Private
 
-public extension ALTAppleAPI {
+public extension ALTAppleAPIError
+{
+    static func unknown(userInfo: [String: Any] = [:], sourceFile: String = #fileID, sourceLine: UInt = #line) -> ALTAppleAPIError
+    {
+        var userInfo = userInfo
+        userInfo[ALTSourceFileErrorKey] = sourceFile
+        userInfo[ALTSourceLineErrorKey] = sourceLine
+        
+        let error = ALTAppleAPIError(.unknown, userInfo: userInfo)
+        return error
+    }
+}
+
+public extension ALTAppleAPI
+{
     @objc func authenticate(appleID unsanitizedAppleID: String,
                             password: String,
                             anisetteData: ALTAnisetteData,
@@ -215,11 +229,12 @@ private extension ALTAppleAPI {
 
                         var request = self.makeTwoFactorCodeRequest(url: verifyURL, dsid: dsid, idmsToken: idmsToken, anisetteData: anisetteData)
                         request.allHTTPHeaderFields?["security-code"] = verificationCode
-
-                        let verifyCodeTask = self.session.dataTask(with: request) { data, _, error in
-                            do {
-                                guard let data = data else { throw error ?? ALTAppleAPIError(.unknown) }
-
+                        
+                        let verifyCodeTask = self.session.dataTask(with: request) { (data, response, error) in
+                            do
+                            {
+                                guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
+                                
                                 guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any] else {
                                     throw URLError(.badServerResponse)
                                 }
@@ -230,10 +245,10 @@ private extension ALTAppleAPI {
                                 switch errorCode {
                                 case -21669: throw ALTAppleAPIError(.incorrectVerificationCode)
                                 default:
-                                    guard let errorDescription = responseDictionary["em"] as? String else { throw ALTAppleAPIError(.unknown) }
-
+                                    guard let errorDescription = responseDictionary["em"] as? String else { throw ALTAppleAPIError.unknown() }
+                                    
                                     let localizedDescription = errorDescription + " (\(errorCode))"
-                                    throw ALTAppleAPIError(.unknown, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+                                    throw ALTAppleAPIError.unknown(userInfo: [NSLocalizedDescriptionKey: localizedDescription])
                                 }
                             } catch {
                                 completionHandler(.failure(error))
@@ -331,20 +346,22 @@ private extension ALTAppleAPI {
 
         requestCodeTask.resume()
     }
-
-    func fetchAccount(session: ALTAppleAPISession, completionHandler: @escaping (Result<ALTAccount, Error>) -> Void) {
-        let url = URL(string: "viewDeveloper.action", relativeTo: baseURL)!
-
-        sendRequest(with: url, additionalParameters: nil, session: session, team: nil) { responseDictionary, requestError in
-            do {
-                guard let responseDictionary = responseDictionary else { throw requestError ?? ALTAppleAPIError(.unknown) }
-
+    
+    func fetchAccount(session: ALTAppleAPISession, completionHandler: @escaping (Result<ALTAccount, Error>) -> Void)
+    {
+        let url = URL(string: "viewDeveloper.action", relativeTo: self.baseURL)!
+        
+        self.sendRequest(with: url, additionalParameters: nil, session: session, team: nil) { (responseDictionary, requestError) in
+            do
+            {
+                guard let responseDictionary = responseDictionary else { throw requestError ?? ALTAppleAPIError.unknown() }
+                
                 guard let account = try self.processResponse(responseDictionary, parseHandler: { () -> Any? in
                     guard let dictionary = responseDictionary["developer"] as? [String: Any] else { return nil }
                     let account = ALTAccount(responseDictionary: dictionary)
                     return account
                 }, resultCodeHandler: nil) as? ALTAccount else {
-                    throw ALTAppleAPIError(.unknown)
+                    throw ALTAppleAPIError.unknown()
                 }
 
                 completionHandler(.success(account))
@@ -378,11 +395,12 @@ private extension ALTAppleAPI {
             request.httpMethod = "POST"
             request.httpBody = bodyData
             httpHeaders.forEach { request.addValue($0.value, forHTTPHeaderField: $0.key) }
-
-            let dataTask = session.dataTask(with: request) { data, _, error in
-                do {
-                    guard let data = data else { throw error ?? ALTAppleAPIError(.unknown) }
-
+            
+            let dataTask = self.session.dataTask(with: request) { (data, response, error) in
+                do
+                {
+                    guard let data = data else { throw error ?? ALTAppleAPIError.unknown() }
+                    
                     guard let responseDictionary = try PropertyListSerialization.propertyList(from: data, format: nil) as? [String: Any],
                           let dictionary = responseDictionary["Response"] as? [String: Any],
                           let status = dictionary["Status"] as? [String: Any]
@@ -395,10 +413,10 @@ private extension ALTAppleAPI {
                     case -20101, -22406: throw ALTAppleAPIError(.incorrectCredentials)
                     case -22421: throw ALTAppleAPIError(.invalidAnisetteData)
                     default:
-                        guard let errorDescription = status["em"] as? String else { throw ALTAppleAPIError(.unknown) }
-
+                        guard let errorDescription = status["em"] as? String else { throw ALTAppleAPIError.unknown() }
+                        
                         let localizedDescription = errorDescription + " (\(errorCode))"
-                        throw ALTAppleAPIError(.unknown, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+                        throw ALTAppleAPIError.unknown(userInfo: [NSLocalizedDescriptionKey: localizedDescription])
                     }
                 } catch {
                     completionHandler(.failure(error))

--- a/Sources/AltSign/ALTAppleAPI+Authentication.swift
+++ b/Sources/AltSign/ALTAppleAPI+Authentication.swift
@@ -248,7 +248,7 @@ private extension ALTAppleAPI {
                                     guard let errorDescription = responseDictionary["em"] as? String else { throw ALTAppleAPIError.unknown() }
                                     
                                     let localizedDescription = errorDescription + " (\(errorCode))"
-                                    throw ALTAppleAPIError.unknown(userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+                                    throw NSError(domain: ALTUnderlyingAppleAPIErrorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
                                 }
                             } catch {
                                 completionHandler(.failure(error))
@@ -416,7 +416,7 @@ private extension ALTAppleAPI {
                         guard let errorDescription = status["em"] as? String else { throw ALTAppleAPIError.unknown() }
                         
                         let localizedDescription = errorDescription + " (\(errorCode))"
-                        throw ALTAppleAPIError.unknown(userInfo: [NSLocalizedDescriptionKey: localizedDescription])
+                        throw NSError(domain: ALTUnderlyingAppleAPIErrorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: localizedDescription])
                     }
                 } catch {
                     completionHandler(.failure(error))

--- a/Sources/CAltSign/Apple API/ALTAppleAPI.m
+++ b/Sources/CAltSign/Apple API/ALTAppleAPI.m
@@ -397,7 +397,7 @@ NS_ASSUME_NONNULL_END
             switch (resultCode)
             {
                 case 35:
-                    return [NSError errorWithDomain:ALTAppleAPIErrorDomain code:ALTAppleAPIErrorInvalidAppIDName userInfo:nil];
+                    return [NSError errorWithDomain:ALTAppleAPIErrorDomain code:ALTAppleAPIErrorInvalidAppIDName userInfo:@{ALTAppNameErrorKey: sanitizedName}];
                     
                 case 9120:
                     return [NSError errorWithDomain:ALTAppleAPIErrorDomain code:ALTAppleAPIErrorMaximumAppIDLimitReached userInfo:nil];

--- a/Sources/CAltSign/Apple API/ALTAppleAPI.m
+++ b/Sources/CAltSign/Apple API/ALTAppleAPI.m
@@ -906,9 +906,9 @@ NS_ASSUME_NONNULL_END
             NSString *errorDescription = [responseDictionary objectForKey:@"userString"] ?: [responseDictionary objectForKey:@"resultString"];
             NSString *localizedDescription = [NSString stringWithFormat:@"%@ (%@)", errorDescription, @(resultCode)];
             
-            NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
-            userInfo[NSLocalizedDescriptionKey] = localizedDescription;
-            tempError = [NSError errorWithDomain:ALTAppleAPIErrorDomain code:ALTAppleAPIErrorUnknown userInfo:userInfo];
+            tempError = [NSError errorWithDomain:ALTUnderlyingAppleAPIErrorDomain code:resultCode userInfo:@{
+                NSLocalizedDescriptionKey: localizedDescription,
+            }];
         }
         
         *error = tempError;

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.h
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.h
@@ -26,7 +26,7 @@ typedef NS_ERROR_ENUM(AltSignErrorDomain, ALTError)
 
 typedef NS_ERROR_ENUM(ALTAppleAPIErrorDomain, ALTAppleAPIError)
 {
-    ALTAppleAPIErrorUnknown,
+    ALTAppleAPIErrorUnknown = 3000,
     ALTAppleAPIErrorInvalidParameters,
     
     ALTAppleAPIErrorIncorrectCredentials,

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.h
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.h
@@ -9,6 +9,8 @@
 #import <Foundation/Foundation.h>
 
 extern NSErrorDomain const AltSignErrorDomain;
+extern NSErrorDomain const ALTAppleAPIErrorDomain;
+extern NSErrorDomain const ALTUnderlyingAppleAPIErrorDomain;
 
 extern NSErrorUserInfoKey const ALTSourceFileErrorKey;
 extern NSErrorUserInfoKey const ALTSourceLineErrorKey;
@@ -22,7 +24,6 @@ typedef NS_ERROR_ENUM(AltSignErrorDomain, ALTError)
     ALTErrorMissingProvisioningProfile,
 };
 
-extern NSErrorDomain const ALTAppleAPIErrorDomain;
 typedef NS_ERROR_ENUM(ALTAppleAPIErrorDomain, ALTAppleAPIError)
 {
     ALTAppleAPIErrorUnknown,

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.h
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.h
@@ -9,6 +9,10 @@
 #import <Foundation/Foundation.h>
 
 extern NSErrorDomain const AltSignErrorDomain;
+
+extern NSErrorUserInfoKey const ALTSourceFileErrorKey;
+extern NSErrorUserInfoKey const ALTSourceLineErrorKey;
+
 typedef NS_ERROR_ENUM(AltSignErrorDomain, ALTError)
 {
     ALTErrorUnknown,

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.h
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.h
@@ -14,6 +14,7 @@ extern NSErrorDomain const ALTUnderlyingAppleAPIErrorDomain;
 
 extern NSErrorUserInfoKey const ALTSourceFileErrorKey;
 extern NSErrorUserInfoKey const ALTSourceLineErrorKey;
+extern NSErrorUserInfoKey const ALTAppNameErrorKey;
 
 typedef NS_ERROR_ENUM(AltSignErrorDomain, ALTError)
 {
@@ -27,36 +28,36 @@ typedef NS_ERROR_ENUM(AltSignErrorDomain, ALTError)
 typedef NS_ERROR_ENUM(ALTAppleAPIErrorDomain, ALTAppleAPIError)
 {
     ALTAppleAPIErrorUnknown = 3000,
-    ALTAppleAPIErrorInvalidParameters,
+    ALTAppleAPIErrorInvalidParameters = 3001,
     
-    ALTAppleAPIErrorIncorrectCredentials,
-    ALTAppleAPIErrorAppSpecificPasswordRequired,
+    ALTAppleAPIErrorIncorrectCredentials = 3002,
+    ALTAppleAPIErrorAppSpecificPasswordRequired = 3003,
     
-    ALTAppleAPIErrorNoTeams,
+    ALTAppleAPIErrorNoTeams = 3004,
     
-    ALTAppleAPIErrorInvalidDeviceID,
-    ALTAppleAPIErrorDeviceAlreadyRegistered,
+    ALTAppleAPIErrorInvalidDeviceID = 3005,
+    ALTAppleAPIErrorDeviceAlreadyRegistered = 3006,
     
-    ALTAppleAPIErrorInvalidCertificateRequest,
-    ALTAppleAPIErrorCertificateDoesNotExist,
+    ALTAppleAPIErrorInvalidCertificateRequest = 3007,
+    ALTAppleAPIErrorCertificateDoesNotExist = 3008,
     
-    ALTAppleAPIErrorInvalidAppIDName,
-    ALTAppleAPIErrorInvalidBundleIdentifier,
-    ALTAppleAPIErrorBundleIdentifierUnavailable,
-    ALTAppleAPIErrorAppIDDoesNotExist,
-    ALTAppleAPIErrorMaximumAppIDLimitReached,
+    ALTAppleAPIErrorInvalidAppIDName = 3009,
+    ALTAppleAPIErrorInvalidBundleIdentifier = 3010,
+    ALTAppleAPIErrorBundleIdentifierUnavailable = 3011,
+    ALTAppleAPIErrorAppIDDoesNotExist = 3012,
+    ALTAppleAPIErrorMaximumAppIDLimitReached = 3013,
     
-    ALTAppleAPIErrorInvalidAppGroup,
-    ALTAppleAPIErrorAppGroupDoesNotExist,
+    ALTAppleAPIErrorInvalidAppGroup = 3014,
+    ALTAppleAPIErrorAppGroupDoesNotExist = 3015,
     
-    ALTAppleAPIErrorInvalidProvisioningProfileIdentifier,
-    ALTAppleAPIErrorProvisioningProfileDoesNotExist,
+    ALTAppleAPIErrorInvalidProvisioningProfileIdentifier = 3016,
+    ALTAppleAPIErrorProvisioningProfileDoesNotExist = 3017,
     
-    ALTAppleAPIErrorRequiresTwoFactorAuthentication,
-    ALTAppleAPIErrorIncorrectVerificationCode,
-    ALTAppleAPIErrorAuthenticationHandshakeFailed,
+    ALTAppleAPIErrorRequiresTwoFactorAuthentication = 3018,
+    ALTAppleAPIErrorIncorrectVerificationCode = 3019,
+    ALTAppleAPIErrorAuthenticationHandshakeFailed = 3020,
     
-    ALTAppleAPIErrorInvalidAnisetteData,
+    ALTAppleAPIErrorInvalidAnisetteData = 3021,
 };
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.m
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.m
@@ -9,7 +9,8 @@
 #import "NSError+ALTErrors.h"
 
 NSErrorDomain const AltSignErrorDomain = @"com.rileytestut.AltSign";
-NSErrorDomain const ALTAppleAPIErrorDomain = @"com.rileytestut.ALTAppleAPI";
+NSErrorDomain const ALTAppleAPIErrorDomain = @"AltStore.AppleDeveloperError";
+NSErrorDomain const ALTUnderlyingAppleAPIErrorDomain = @"Apple.APIError";
 
 NSErrorUserInfoKey const ALTSourceFileErrorKey = @"ALTSourceFile";
 NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.m
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.m
@@ -8,7 +8,7 @@
 
 #import "NSError+ALTErrors.h"
 
-NSErrorDomain const AltSignErrorDomain = @"com.rileytestut.AltSign";
+NSErrorDomain const AltSignErrorDomain = @"AltSign.Error";
 NSErrorDomain const ALTAppleAPIErrorDomain = @"AltStore.AppleDeveloperError";
 NSErrorDomain const ALTUnderlyingAppleAPIErrorDomain = @"Apple.APIError";
 

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.m
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.m
@@ -125,7 +125,7 @@ NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";
             return NSLocalizedString(@"The provided parameters are invalid.", @"");
             
         case ALTAppleAPIErrorIncorrectCredentials:
-            return NSLocalizedString(@"Incorrect Apple ID or password.", @"");
+            return NSLocalizedString(@"Your Apple ID or password is incorrect.", @"");
             
         case ALTAppleAPIErrorNoTeams:
             return NSLocalizedString(@"You are not a member of any development teams.", @"");
@@ -192,6 +192,9 @@ NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";
 {
     switch ((ALTAppleAPIError)self.code)
     {
+        case ALTAppleAPIErrorIncorrectCredentials:
+            return NSLocalizedString(@"Please make sure you entered both your Apple ID and password correctly and try again.", @"");
+            
         case ALTAppleAPIErrorInvalidAnisetteData:
 #if TARGET_OS_OSX
             return NSLocalizedString(@"Make sure this computer's date & time matches your iOS device and try again.", @"");

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.m
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.m
@@ -11,6 +11,9 @@
 NSErrorDomain const AltSignErrorDomain = @"com.rileytestut.AltSign";
 NSErrorDomain const ALTAppleAPIErrorDomain = @"com.rileytestut.ALTAppleAPI";
 
+NSErrorUserInfoKey const ALTSourceFileErrorKey = @"ALTSourceFile";
+NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";
+
 @implementation NSError (ALTError)
 
 + (void)load

--- a/Sources/CAltSign/Categories/NSError+ALTErrors.m
+++ b/Sources/CAltSign/Categories/NSError+ALTErrors.m
@@ -14,6 +14,7 @@ NSErrorDomain const ALTUnderlyingAppleAPIErrorDomain = @"Apple.APIError";
 
 NSErrorUserInfoKey const ALTSourceFileErrorKey = @"ALTSourceFile";
 NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";
+NSErrorUserInfoKey const ALTAppNameErrorKey = @"appName";
 
 @implementation NSError (ALTError)
 
@@ -146,7 +147,15 @@ NSErrorUserInfoKey const ALTSourceLineErrorKey = @"ALTSourceLine";
             return NSLocalizedString(@"There is no certificate with the requested serial number for this team.", @"");
             
         case ALTAppleAPIErrorInvalidAppIDName:
-            return NSLocalizedString(@"The name for this app is invalid.", @"");
+        {
+            NSString *appName = self.userInfo[ALTAppNameErrorKey];
+            if (appName != nil)
+            {
+                return [NSString stringWithFormat:NSLocalizedString(@"The name “%@” contains invalid characters.", @""), appName];
+            }
+            
+            return NSLocalizedString(@"The name of this app contains invalid characters.", @"");
+        }
             
         case ALTAppleAPIErrorInvalidBundleIdentifier:
             return NSLocalizedString(@"The bundle identifier for this app is invalid.", @"");

--- a/Sources/CAltSign/Signing/ALTSigner.mm
+++ b/Sources/CAltSign/Signing/ALTSigner.mm
@@ -474,7 +474,11 @@ std::string CertificatesContent(ALTCertificate *altCertificate)
         }
         catch (std::exception& exception)
         {
-            NSError *error = [NSError errorWithDomain:AltSignErrorDomain code:ALTErrorUnknown userInfo:@{NSLocalizedDescriptionKey: @(exception.what())}];
+            NSError *error = [NSError errorWithDomain:AltSignErrorDomain code:ALTErrorUnknown userInfo:@{
+                NSLocalizedFailureReasonErrorKey: @(exception.what()),
+                ALTSourceFileErrorKey: @(__FILE__).lastPathComponent,
+                ALTSourceLineErrorKey: @(__LINE__)
+            }];
             finish(NO, error);
         }
     });

--- a/Sources/CAltSign/Signing/ALTSigner.mm
+++ b/Sources/CAltSign/Signing/ALTSigner.mm
@@ -408,7 +408,7 @@ std::string CertificatesContent(ALTCertificate *altCertificate)
         }
         
         for (ALTApplication *appExtension in application.appExtensions)
-        {   
+        {
             NSError *error = prepareApp(appExtension);
             if (error != nil)
             {


### PR DESCRIPTION
- when using Altstore 2.0, I had noticed that the Sign-In didn't ask for verification code unlike current sidestore.
- Since iOS 18.1 had removed the option of getting a verification code manually via settings screen, if this works this can eliminate the need for verification code generation via iCloud sign-in.

Disclaimer: I haven't looked in depth at Riley's code on why the 2FA requirement is gone now though.

This is just a rebase of rileytesut/AltSign on sidestore/AltSign with merge conflicts resolved.