### PR TITLE
Fix locale with two factor code request

### DIFF
--- a/AltSign/Sources/ALTAppleAPI+Authentication.swift
+++ b/AltSign/Sources/ALTAppleAPI+Authentication.swift
@@ -454,7 +454,7 @@ private extension ALTAppleAPI {
             "X-Mme-Device-Id": anisetteData.deviceUniqueIdentifier,
             "X-MMe-Client-Info": anisetteData.deviceDescription,
             "X-Apple-I-Client-Time": dateFormatter.string(from: anisetteData.date),
-            "X-Apple-Locale": anisetteData.locale.identifier,
+            "X-Apple-Locale": String(anisetteData.locale.identifier.prefix { $0 != "@" }),
             "X-Apple-I-TimeZone": anisetteData.timeZone.abbreviation() ?? "PST"
         ]
 


### PR DESCRIPTION
This fixes the `X-Apple-Locale` header when requesting a two factor code. The issue may only occur if the region doesn't match the default language, apparently the "en_AU@rg=dezzzz" locale indicates a de/Germany region override.

More info:
https://mastodon.social/@aaronk6/112639596704564456

Fixes https://github.com/SideStore/SideStore/issues/1231.

<details>
<summary>Before: trusted-device 2FA request fails</summary>

```http
GET https://gsa.apple.com/auth/verify/trusteddevice
Accept: application/x-buddyml
Accept-Language: en-us
Content-Type: application/x-plist
User-Agent: Xcode
X-Apple-App-Info: com.apple.gs.xcode.auth
X-Apple-I-Client-Time: 2026-04-30T22:12:00Z
X-Apple-I-MD: [redacted]
X-Apple-I-MD-LU: [redacted]
X-Apple-I-MD-M: [redacted]
X-Apple-I-MD-RINFO: 17106176
X-Apple-I-TimeZone: GMT+2
X-Apple-Identity-Token: [redacted]
X-Apple-Locale: en_US@rg=dezzzz
X-MMe-Client-Info: <MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>
X-Mme-Device-Id: [redacted]
X-Xcode-Version: 11.2 (11B41)

GET https://gsa.apple.com/auth/verify/trusteddevice
Status: 500
Connection: keep-alive
Content-Encoding: gzip
Content-Type: text/xml;charset=UTF-8
Date: Thu, 30 Apr 2026 22:12:01 GMT
Server: Apple
X-Apple-I-Request-ID: 9cbb0b3d-44e1-11f1-afa1-912d75122af4
X-BuildVersion: R9
X-Frame-Options: DENY, SAMEORIGIN
```
</details>

<details>
<summary>After: trusted-device 2FA request succeeds</summary>

```http
GET https://gsa.apple.com/auth/verify/trusteddevice
Accept: application/x-buddyml
Accept-Language: en-us
Content-Type: application/x-plist
User-Agent: Xcode
X-Apple-App-Info: com.apple.gs.xcode.auth
X-Apple-I-Client-Time: 2026-04-30T22:13:09Z
X-Apple-I-MD: [redacted]
X-Apple-I-MD-LU: [redacted]
X-Apple-I-MD-M: [redacted]
X-Apple-I-MD-RINFO: 17106176
X-Apple-I-TimeZone: GMT+2
X-Apple-Identity-Token: [redacted]
X-Apple-Locale: en_US
X-MMe-Client-Info: <MacBookPro13,2> <macOS;13.1;22C65> <com.apple.AuthKit/1 (com.apple.dt.Xcode/3594.4.19)>
X-Mme-Device-Id: [redacted]
X-Xcode-Version: 11.2 (11B41)

GET https://gsa.apple.com/auth/verify/trusteddevice
Status: 200
Cache-Control: no-store
Content-Encoding: gzip
Content-Language: en-US-x-lvariant-USA
Content-Type: text/xml;charset=UTF-8
Date: Thu, 30 Apr 2026 22:13:10 GMT
Server: Apple
Set-Cookie: [redacted]
X-Apple-I-Request-ID: c5def655-44e1-11f1-afa1-912d75122af4
X-BuildVersion: R9
X-Frame-Options: DENY, SAMEORIGIN
```