### PR TITLE
Default to 0644 when IPA entries have no Unix permissions

### DIFF
--- a/AltSign/Categories/NSFileManager+Zip.m
+++ b/AltSign/Categories/NSFileManager+Zip.m
@@ -220,6 +220,11 @@ char ALTDirectoryDeliminator = '/';
             } while (result > 0);
             
             short permissions = (info.external_fa >> 16) & 0x01FF;
+            if (permissions == 0) {
+                // No Unix mode bits set -- archive was likely created on Windows.
+                // Use a readable default so signing can proceed. (Fixes issue #447.)
+                permissions = 0644;
+            }
             if (![self setAttributes:@{NSFilePosixPermissions: @(permissions)} ofItemAtPath:fileURL.path error:error])
             {
                 finish();


### PR DESCRIPTION
## Summary

IPAs created with ZIP tooling on Windows store NTFS file attributes in the ZIP `external_fa` field and leave the Unix mode bits (the high 16 bits) unset. When `unzipArchiveAtURL:toDirectory:progress:error:` extracts such an archive, `(info.external_fa >> 16) & 0x01FF` evaluates to `0`, and that mode is then applied via `setAttributes:`. The extracted files end up with mode `0000`, so the later reads performed while signing the app fail with a permission error — which surfaces to users as **"You don't have permission."**

This is a common report from people building IPAs on Windows.

## Fix

When no Unix mode bits are present, fall back to `0644` before applying permissions, so the archive extracts with readable files. Archives that carry valid Unix permissions are unaffected.

## Testing

Built SideStore against this change and installed an IPA that was previously failing with the permission error on a Windows-zipped build; it now extracts and installs cleanly. IPAs produced by Xcode (which carry proper Unix permissions) are unchanged.

Fixes SideStore/SideStore#447
